### PR TITLE
fix: update tests for new constructor syntax

### DIFF
--- a/spec/big_decimal_inspect_spec.rb
+++ b/spec/big_decimal_inspect_spec.rb
@@ -1,13 +1,13 @@
 describe BigDecimal do
   describe "#inspect" do
     context "with decimal points" do
-      subject { BigDecimal.new("5000.1234").inspect }
+      subject { BigDecimal("5000.1234").inspect }
 
       it { is_expected.to eq('#<BigDecimal:"5000.1234">') }
     end
 
     context "without decimal points" do
-      subject { BigDecimal.new(5000).inspect }
+      subject { BigDecimal(5000).inspect }
 
       it { is_expected.to eq('#<BigDecimal:"5000">') }
     end


### PR DESCRIPTION
### Why
`BigDecimal.new` is no longer supported. Fix tests by removing this syntax.

### What is changing
- Removed calls to `BigDecimal.new`