### PR TITLE
ci: use variable for default runs-on value [skip deploy]

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   stale:
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.DEFAULT_RUNS_ON }}
     steps:
       - uses: actions/stale@v4
         with:


### PR DESCRIPTION
### Why

The `ubuntu-latest` label is is moving to Ubuntu 24 starting Dec 5th, 2024.

We are changing repositories to use an org-wide variable currently set to `ubuntu-22.04`.

- Ubuntu 22 is an LTS release and should remain supported until 2027.
- Using an org-wide actions variable makes it easier to mass-migrate repos in the future, while still making it relatively easy to customize per-repo, if necessary, using a repostory-level variable to override the org-wide one.

### What Changed

- Replace usage of `ubuntu-latest` / `ubuntu-22.04` with `${{ vars.DEFAULT_RUNS_ON }}` in workflow files
